### PR TITLE
Max SDK Version 18

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ unzip master.zip
 ```
 4-1) Create a symbolic link to android executable
 ```bash
-sudo ln -s YourAndroidSDKPath/tools/android /bin/android
+sudo ln -s $ANDROID_HOME/tools/android /bin/android
 ```
 
 5) Run setup.sh

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ git clone https://github.com/MartinBaptiste/Robolectric-V-V.git
 
 7) Run IntelliJ and open this project
 
-8) Change SDK compiler to Android SDK 18 (4.3.1) or 19 (4.4.2) "File -> Project Structure." and set "Project Settings -> Project -> Project SDK -> Edit"
+8) Change SDK compiler to Android SDK 18 (4.3.1) "File -> Project Structure." and set "Project Settings -> Project -> Project SDK -> Edit"
 
 9) Change the version of android in pom.xml if needed
 ```xml


### PR DESCRIPTION
Robolectrie doesn't support version 19 of Android SDK 
https://github.com/robolectric/robolectric/blob/master/robolectric/src/main/java/org/robolectric/SdkConfig.java
http://robolectric.org/eclipse-quick-start/
